### PR TITLE
Patches for lua 5.3.3.

### DIFF
--- a/documentation/manual/input/systems/lattice.rst
+++ b/documentation/manual/input/systems/lattice.rst
@@ -17,7 +17,7 @@ Returns:
 
 .. math::
 
-    H = -t \sum_{<r,r'>,\sigma} c^\dagger_{r,\sigma} c_{r',\sigma} + U \sum_r n_{r,\uparrow} n_{r,\downarrow}
+    H = -t \sum_{\langle r,r' \rangle,\sigma} c^\dagger_{r,\sigma} c_{r',\sigma} + U \sum_r n_{r,\uparrow} n_{r,\downarrow}
 
 using a single-particle basis of Bloch functions, :math:`\psi_k`:
 
@@ -112,7 +112,7 @@ Returns:
 
 .. math::
 
-    H = -t \sum_{<r,r'>,\sigma} c^\dagger_{r,\sigma} c_{r',\sigma} + U \sum_r n_{r,\uparrow} n_{r,\downarrow}
+    H = -t \sum_{\langle r,r' \rangle,\sigma} c^\dagger_{r,\sigma} c_{r',\sigma} + U \sum_r n_{r,\uparrow} n_{r,\downarrow}
 
 using a single-particle basis of functions in real-space.
 

--- a/documentation/manual/integrals.rst
+++ b/documentation/manual/integrals.rst
@@ -103,10 +103,10 @@ Hamiltonian.
 if :math:`a = j = b = 0`, :math:`\epsilon_i = x`, the single-particle eigenvalue
 of the i-th orbital.
 
-if :math:`j = b = 0`, :math:`< i | h | a > = x`, the one-body Hamiltonian matrix element
+if :math:`j = b = 0`, :math:`\langle i | h | a \rangle = x`, the one-body Hamiltonian matrix element
 between the i-th and a-th orbitals, where :math:`h = T+V_{ext}`.
 
-otherwise :math:`< i j | 1/r_{12} | a b > = x`, the Coulomb integral between
+otherwise :math:`\langle i j | 1/r_{12} | a b \rangle = x`, the Coulomb integral between
 the i-a co-density and the j-b codensity.  Note the Coulomb
 integrals are given in Chemists' notation.
 

--- a/lib/aotus/LuaFortran/lua_fif.f90
+++ b/lib/aotus/LuaFortran/lua_fif.f90
@@ -50,11 +50,12 @@ module lua_fif
       integer(kind=c_int) :: lua_gettop
     end function lua_gettop
 
-    subroutine lua_insert(L, index) bind(c, name="lua_insert")
+    subroutine lua_rotate(L, index, n) bind(c, name="lua_rotate")
       use, intrinsic :: iso_c_binding
       type(c_ptr), value :: L
       integer(kind=c_int), value :: index
-    end subroutine lua_insert
+      integer(kind=c_int), value :: n
+    end subroutine lua_rotate
 
     function lua_isNumber(L, index) bind(c, name="lua_isnumber")
       use, intrinsic :: iso_c_binding
@@ -264,5 +265,14 @@ module lua_fif
     end function luaL_newmetatable
 
   end interface
+
+contains
+  subroutine lua_insert(L, index)
+    use, intrinsic :: iso_c_binding
+    type(c_ptr), value :: L
+    integer(kind=c_int), value :: index
+    integer(kind=c_int) :: n=1
+    call lua_rotate(L, index, n)
+  end subroutine lua_insert
 
 end module lua_fif

--- a/lib/aotus/LuaFortran/wrap_lua_dump.c
+++ b/lib/aotus/LuaFortran/wrap_lua_dump.c
@@ -49,7 +49,7 @@ const char* dump_lua_toBuf(lua_State *L, int *length, int *ierr)
   dat.space = 1024;
   dat.container = malloc(dat.space);
 
-  errcode = lua_dump(L, buf_writer, &dat);
+  errcode = lua_dump(L, buf_writer, &dat, 0);
 
   (*ierr) = errcode;
   (*length) = dat.length;


### PR DESCRIPTION
Here's a couple of patches that were necessary to make the code compile on my computer with Lua 5.3.

The hack for lua_insert is a bit ugly, because lua.h defines
#define lua_insert(L,idx)       lua_rotate(L, (idx), 1)

but I'm not fluent enough in Fortran to write an interface that wraps a macro. I guess the cleaner solution would be to write a C function that calls lua_insert which can be interfaced from Fortran.

The second change is that the interface to lua_dump seems to have changed
 LUA_API int (lua_dump) (lua_State *L, lua_Writer writer, void *data, int strip);
where strip toggles stripping some sort of debug info...