### PR TITLE
Use flush statement in preference to flush subroutine

### DIFF
--- a/lib/local/environment_report.F90
+++ b/lib/local/environment_report.F90
@@ -77,7 +77,7 @@ contains
         end if
 
         write (io_unit,'(1X,64("="))')
-        call flush(io_unit)
+        flush(io_unit)
 
         call print_info()
 


### PR DESCRIPTION
The former is preferred from F2003 onwards and the latter is
a (commonly implemented) extension which breaks some compilers (e.g.
gfortran 7.1) if a strict standard flag is used.