### PR TITLE
Fix serial compilation

### DIFF
--- a/.default.nix
+++ b/.default.nix
@@ -3,8 +3,8 @@ let
   nixpkgs = (hostPkgs.fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs-channels";
-    rev = "nixos-unstable";
-    sha256 = "1rc1pjnvfi194gka45zc1nivzsncc819kvxlfv277l2c8ryhgbpc";
+    rev = "nixos-18.03";
+    sha256 = "1g4vfvpvdbgap84qkngzcai2gqwbpv77sqyswv884k1qxf2xji7j";
   });
 in
   with import nixpkgs {
@@ -33,7 +33,6 @@ in
       gcc
       gdb
       gfortran
-      gfortran.cc.lib
       hdf5
       liblapack
       libuuid

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,16 @@ matrix:
       python: '3.5'
       env:
         - USE_CMAKE=true
+    - os: linux
+      python: '2.7'
+      env:
+        - USE_CMAKE=true
+        - SERIAL=true
+    - os: linux
+      python: '3.5'
+      env:
+        - USE_CMAKE=true
+        - SERIAL=true
 
 before_install:
   # Dependencies are downloaded in $HOME/Downloads and installed in $HOME/Deps
@@ -60,16 +70,16 @@ install:
 
 before_script:
   - >
-    if [[ "$USE_CMAKE" = true ]]; then
+    if [[ "$USE_CMAKE" = "true" && "$SERIAL" != "true" ]]; then
       ./cmakeconfig.py --type=release \
-                    --fc=mpif90 \
-                    --cc=mpicc \
-                    --mpi \
-                    --lua=$LUA_ROOT \
-                    --mpi-with-scalapack \
-                    --scalapack="-L$ScaLAPACK_ROOT/lib -lscalapack" \
-                    --lanczos="-L$DEPS/trlan/lib -ltrlan" \
-                    --exe-name="hande.travis.linux.cmake.x"
+                       --fc=mpif90 \
+                       --cc=mpicc \
+                       --mpi \
+                       --lua=$LUA_ROOT \
+                       --mpi-with-scalapack \
+                       --scalapack="-L$ScaLAPACK_ROOT/lib -lscalapack" \
+                       --lanczos="-L$DEPS/trlan/lib -ltrlan" \
+                       --exe-name="hande.travis.mpi.linux.cmake.x"
       # This is equivalent to
       # cmake -H. -Bbuild \
       #           -DENABLE_HDF5=ON \
@@ -82,7 +92,34 @@ before_script:
       #           -DENABLE_SCALAPACK=ON \
       #           -DSCALAPACK_LIBRARIES="-L$ScaLAPACK_ROOT/lib -lscalapack" \
       #           -DTRLan_LIBRARIES="-L$DEPS/trlan/lib -ltrlan" \
-      #           -DHANDE_EXE_NAME="hande.travis.linux.cmake.x"
+      #           -DHANDE_EXE_NAME="hande.travis.mpi.linux.cmake.x"
+  elif [[ "$USE_CMAKE" = "true" && "$SERIAL" = "true" ]]; then
+      ./cmakeconfig.py --type=release \
+                       --fc=gfortran \
+                       --cc=gcc \
+                       --lua=$LUA_ROOT \
+                       --dsfmt-mexp=86243 \
+                       --single \
+                       --popcnt \
+                       --det-size=64 \
+                       --pop-size=64 \
+                       --backtrace \
+                       --exe-name="hande.travis.serial.linux.cmake.x"
+      # This is equivalent to
+      # cmake -H. -Bbuild \
+      #           -DCMAKE_BUILD_TYPE=Release \
+      #           -DCMAKE_Fortran_COMPILER=gfortran \
+      #           -DCMAKE_C_COMPILER=gcc \
+      #           -DLUA_ROOT=$LUA_ROOT \
+      #           -DENABLE_HDF5=ON \
+      #           -DENABLE_UUID=ON \
+      #           -DHANDE_DSFMT_MEXP="86243" \
+      #           -DENABLE_SINGLE_PRECISION="True" \
+      #           -DENABLE_INTRINSIC_POPCNT="True" \
+      #           -DHANDE_DET_SIZE="64" \
+      #           -DHANDE_POP_SIZE="64" \
+      #           -DENABLE_BACKTRACE="True" \
+      #           -DHANDE_EXE_NAME="hande.travis.serial.linux.cmake.x"
     else
       tools/mkconfig.py travis.linux
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,11 +98,6 @@ before_script:
                        --fc=gfortran \
                        --cc=gcc \
                        --lua=$LUA_ROOT \
-                       --dsfmt-mexp=86243 \
-                       --single \
-                       --popcnt \
-                       --det-size=64 \
-                       --pop-size=64 \
                        --backtrace \
                        --exe-name="hande.travis.serial.linux.cmake.x"
       # This is equivalent to
@@ -113,11 +108,6 @@ before_script:
       #           -DLUA_ROOT=$LUA_ROOT \
       #           -DENABLE_HDF5=ON \
       #           -DENABLE_UUID=ON \
-      #           -DHANDE_DSFMT_MEXP="86243" \
-      #           -DENABLE_SINGLE_PRECISION="True" \
-      #           -DENABLE_INTRINSIC_POPCNT="True" \
-      #           -DHANDE_DET_SIZE="64" \
-      #           -DHANDE_POP_SIZE="64" \
       #           -DENABLE_BACKTRACE="True" \
       #           -DHANDE_EXE_NAME="hande.travis.serial.linux.cmake.x"
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ before_script:
       #           -DSCALAPACK_LIBRARIES="-L$ScaLAPACK_ROOT/lib -lscalapack" \
       #           -DTRLan_LIBRARIES="-L$DEPS/trlan/lib -ltrlan" \
       #           -DHANDE_EXE_NAME="hande.travis.mpi.linux.cmake.x"
-  elif [[ "$USE_CMAKE" = "true" && "$SERIAL" = "true" ]]; then
+    elif [[ "$USE_CMAKE" = "true" && "$SERIAL" = "true" ]]; then
       ./cmakeconfig.py --type=release \
                        --fc=gfortran \
                        --cc=gcc \

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,14 +116,19 @@ before_script:
 
 script:
   - >
-    if [[ "$USE_CMAKE" = true ]]; then
+    if [[ "$USE_CMAKE" = "true" ]]; then
       cmake --build build -- VERBOSE=1
     else
       make
     fi
   # Only run a short subset of the tests
   - cd test_suite
-  - $DEPS/testcode/bin/testcode.py -c vquick -v
+  - >
+    if [[ "$SERIAL" = "true" ]]; then
+      $DEPS/testcode/bin/testcode.py -c vquick_serial -v
+    else
+      $DEPS/testcode/bin/testcode.py -c vquick -v
+    fi
 
 notifications:
   email:

--- a/cmake/custom/hdf5.cmake
+++ b/cmake/custom/hdf5.cmake
@@ -15,7 +15,7 @@
 #
 # autocmake.yml configuration::
 #
-#   docopt: "--hdf5 Enable HDF5 [default: True]."
+#   docopt: "--hdf5=<HDF5> Enable HDF5 [default: True]."
 #   define: "'-DENABLE_HDF5=\"{0}\"'.format(arguments['--hdf5'])"
 
 option_with_print(ENABLE_HDF5 "Enable usage of HDF5 (requires Fortran 2003 bindings)" ON)

--- a/cmake/custom/mpi.cmake
+++ b/cmake/custom/mpi.cmake
@@ -43,7 +43,7 @@ endif()
 include(CMakeDependentOption)
 cmake_dependent_option(
   ENABLE_SCALAPACK "Enable usage of ScaLAPACK" OFF
-  "ENABLE_MPI" ON
+  "NOT ENABLE_MPI" ON
   )
 if(ENABLE_SCALAPACK)
   set(USE_ScaLAPACK ON)

--- a/cmake/custom/uuid.cmake
+++ b/cmake/custom/uuid.cmake
@@ -16,7 +16,7 @@
 #
 # autocmake.yml configuration::
 #
-#   docopt: "--uuid Whether to activate UUID generation [default: True]."
+#   docopt: "--uuid=<UUID> Whether to activate UUID generation [default: True]."
 #   define: "'-DENABLE_UUID=\"{0}\"'.format(arguments['--uuid'])"
 
 option_with_print(ENABLE_UUID "Enable usage of UUID" ON)

--- a/cmakeconfig.py
+++ b/cmakeconfig.py
@@ -37,8 +37,8 @@ Options:
   --det-size=<HANDE_DET_SIZE>            An integer among 32 or 64 [default: 32].
   --pop-size=<HANDE_POP_SIZE>            An integer among 32 or 64 [default: 32].
   --exe-name=<HANDE_EXE_NAME>            [default: "hande.cmake.x"].
-  --hdf5                                 Enable HDF5 [default: True].
-  --uuid                                 Whether to activate UUID generation [default: True].
+  --hdf5=<HDF5>                          Enable HDF5 [default: True].
+  --uuid=<UUID>                          Whether to activate UUID generation [default: True].
   --lanczos=<TRLan_LIBRARIES>            Set TRLan libraries to be linked in [default: ''].
   --single                               Enable usage of single precision, where appropriate [default: False].
   --backtrace                            Enable backtrace functionality [default: False].

--- a/documentation/manual/compile-with-cmake.rst
+++ b/documentation/manual/compile-with-cmake.rst
@@ -69,8 +69,8 @@ The help menu for the ``cmakeconfig.py`` script shows the available options:
      --det-size=<HANDE_DET_SIZE>            An integer among 32 or 64 [default: 32].
      --pop-size=<HANDE_POP_SIZE>            An integer among 32 or 64 [default: 32].
      --exe-name=<HANDE_EXE_NAME>            [default: "hande.cmake.x"].
-     --hdf5                                 Enable HDF5 [default: True].
-     --uuid                                 Whether to activate UUID generation [default: True].
+     --hdf5=<HDF5>                          Enable HDF5 [default: True].
+     --uuid=<UUID>                          Whether to activate UUID generation [default: True].
      --lanczos=<TRLan_LIBRARIES>            Set TRLan libraries to be linked in [default: ''].
      --single                               Enable usage of single precision, where appropriate [default: False].
      --backtrace                            Enable backtrace functionality [default: False].

--- a/test_suite/jobconfig
+++ b/test_suite/jobconfig
@@ -108,16 +108,13 @@ quick64 = quick
           dmqmc_real_64/np4/ueg_n4_rs2_e4/
           fciqmc_real_64/np1/He2-aug-cc-pVDZ_real_64_restart_replica_legacyv1/
           fciqmc_real_64/np4/He2-aug-cc-pVDZ_real_64_SS/
-          
-vquick =   ccmc/np1/Ne-RHF-cc-pVDZ-Lz-CCSDTQ5-multispawn-short
+
+vquick_serial = ccmc/np1/Ne-RHF-cc-pVDZ-Lz-CCSDTQ5-multispawn-short
            ccmc/np1/Ne-RHF-cc-pVDZ-Lz-CCSDTQ5-multispawn-short-debug-logging
            ccmc/np1/Ne-RHF-cc-pVDZ_ccmc_even_selection
            ccmc/np1/polyyne_complex_ccsdt
-           ccmc/np2/H2O-cc-pVDZ_tau_search
-           ccmc/np2/H2O-cc-pVDZ_ccsdt
            ccmc_real_32/np1/HOCl-6-31g_ccsd_short
            dmqmc/np1/heisenberg_1d
-           dmqmc_real_32/np2/heisenberg_4_gs_entropy
            fci/H2-RHF-cc-pVTZ-Lz/
            fci/H2O-RHF-sto-2g
            fci/H2O-RHF-sto-2g-contiguous-broadcast
@@ -141,31 +138,36 @@ vquick =   ccmc/np1/Ne-RHF-cc-pVDZ-Lz-CCSDTQ5-multispawn-short
            fciqmc/np1/H2O-RHF-cc-pVTZ-debug-logging
            fciqmc/np1/hubbard_real_1d_change_sys
            fciqmc/np1/polyyne_complex_fciqmc
-           fciqmc/np2/polyyne_complex_replica_restart_legacyv1/
-           fciqmc/np2/ueg_n10_rs2_e4_tau_search
            fciqmc_real_32/np1/He2-aug-cc-pVDZ_real_32_SS
            fciqmc_real_32/np1/He2-aug-cc-pVDZ_real_32_SS_replica
            fciqmc_real_32/np1/He2-aug-cc-pVDZ_real_32_SS_Extra_MPI
-           fciqmc_real_32/np4/ueg_n7_rs1_e1_SS_cisdtq_replica
            ifciqmc/np1/hubbard_k_1d_ifciqmc
            ifciqmc/np1/hubbard_k_1d_ifciqmc_cas
            ifciqmc/np1/hubbard_k_nontilted_2d_ifciqmc
-           ifciqmc/np4/H2O-RHF-cc-pVTZ-non-block-hdf5-system
            ifciqmc_real_32/np1/hubbard_k_1d_ifciqmc_real_32
            ifciqmc_real_32/np1/hubbard_k_1d_ifciqmc_real_32_SS
-           ifciqmc_real_32/np2/polyyne_complex_ifciqmc-real32
-           ifciqmc_real_32/np4/hubbard_k_1d_ifciqmc_ss_restart
            lanczos/hubbard_k_nontilted_2d_lanczos
            lanczos/hubbard_k_tilted_2d_sparse
            lanczos/hubbard_real_nontilted_2d_direct
            lanczos/hubbard_real_rectangle_2d_lanczos
            mc_canonical_estimates/np1/H2O_ccpvdz_RHF
-           mc_canonical_estimates/np2/H2O_ccpvdz_RHF
            mc_hilbert_space/np1/hf_hilbert_space
            mc_hilbert_space/np1/hubbard_k_tilted_2d_mchilbert
            mc_hilbert_space/np1/ueg_n7_rs1_e3_hilbert_space
            mc_hilbert_space/np1/ueg_n7_rs1_e3_hilbert_space_write-to-file
            simple_fciqmc/hubbard_k_nontilted_2d_sfciqmc
+
+vquick =   vquick_serial
+           ccmc/np2/H2O-cc-pVDZ_tau_search
+           ccmc/np2/H2O-cc-pVDZ_ccsdt
+           dmqmc_real_32/np2/heisenberg_4_gs_entropy
+           fciqmc/np2/polyyne_complex_replica_restart_legacyv1/
+           fciqmc/np2/ueg_n10_rs2_e4_tau_search
+           ifciqmc/np4/H2O-RHF-cc-pVTZ-non-block-hdf5-system
+           fciqmc_real_32/np4/ueg_n7_rs1_e1_SS_cisdtq_replica
+           ifciqmc_real_32/np2/polyyne_complex_ifciqmc-real32
+           ifciqmc_real_32/np4/hubbard_k_1d_ifciqmc_ss_restart
+           mc_canonical_estimates/np2/H2O_ccpvdz_RHF
 
 vquick64 = vquick
            ccmc_real_64/np2/NH3-6-31g_ccsdt_linked_short


### PR DESCRIPTION
This PR closes #8 and #9
- [x] Fixes a bug in ScaLAPACK detection in a serial compilation
- [x] Fixes an inconsistency in the use of HDF5 and UUID when using `cmakeconfig.py` _vs_ bare CMake.
- [x] Adds a couple of serial builds on Linux, so that we catch breaking changes like the ScaLAPACK one.
