### PR TITLE
Fix output formatting bugs

### DIFF
--- a/lib/local/utils.F90
+++ b/lib/local/utils.F90
@@ -208,7 +208,7 @@ contains
         if (i == 0 .or. i==1) then
             logi = 1.0
         else
-            logi = log10(real(abs(i)+1,dp))
+            logi = log10(abs(real(i,dp))+1)
         end if
         if (i < 0) logi = logi + 1
 
@@ -238,7 +238,7 @@ contains
         if (i == 0 .or. i==1) then
             logi = 1.0
         else
-            logi = log10(real(abs(i)+1,dp))
+            logi = log10(abs(real(i,dp))+1)
         end if
         if (i < 0) logi = logi + 1
 

--- a/src/particle_t_utils.f90
+++ b/src/particle_t_utils.f90
@@ -103,7 +103,7 @@ contains
         end if
 
         if (parent .and. verbose) then
-            write (iunit,'(1X,a53,f7.2)') 'Memory allocated per core for main walker list (MB): ', &
+            write (iunit,'(1X,a53,f9.2)') 'Memory allocated per core for main walker list (MB): ', &
                                       size_main_walker*real(max_nstates_elements,p)/10**6
             write (iunit,'(1X,a48,'//int_fmt(max_nstates_elements,1)//')') &
                     'Number of elements per core in main walker list:', max_nstates_elements

--- a/src/qmc.F90
+++ b/src/qmc.F90
@@ -951,7 +951,7 @@ contains
             max_nspawned_states = int((-real(max_nspawned_states,p)*10**6)/(2*size_spawned_walker))
         end if
         if (parent) then
-            write (io_unit,'(1X,a57,f7.2)') &
+            write (io_unit,'(1X,a57,f9.2)') &
                 'Memory allocated per core for spawned walker lists (MB): ', &
                 size_spawned_walker*real(2*max_nspawned_states,p)/10**6
             write (io_unit,'(1X,a51,1x,i0,/)') &


### PR DESCRIPTION
The int_fmt function failed to give a valid format string for the integer -2147483648
which occurs while printing error messages.