### PR TITLE
Generate git_info.f90 and print_info.c at build time with make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,5 +476,12 @@ $(DEST)/git_info.f90 $(DEST)/print_info.c : | $(DEST)
 $(DEST)/git_info.f90 $(DEST)/print_info.c:
 	python tools/configurator.py -d $(DEST) Fortran_compiler $(FC) build_type $(OPT) C_compiler $(CC)
 
-vpath git_info.f90 $(DEST)
-vpath print_info.c $(DEST)
+# Avoid using vpath to set the search path for the generated files as this doesn't work
+# with make 3.81 (which is sadly still in use...). Instead duplicate pattern rules for the
+# case where source and object files are in DEST.
+#vpath git_info.f90 $(DEST)
+#vpath print_info.c $(DEST)
+$(DEST)/print_info.o: $(DEST)/print_info.c
+	$(CC) $(CPPFLAGS) $(INCLUDE) -c $(CFLAGS) $< -o $@
+$(DEST)/git_info.o: $(DEST)/git_info.f90
+	$(FC) -c $(FFLAGS) $< -o $@ $(F90_MOD_FLAG)$(DEST)

--- a/tools/configurator.py
+++ b/tools/configurator.py
@@ -25,6 +25,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #
 
+import argparse
 import os
 import sys
 import subprocess
@@ -164,3 +165,34 @@ def run_git(args):
         sys.stderr.write(stderr)
         sys.stderr.write('Git execution failed: {}'.format(e))
     return stdout.rstrip()
+
+def parse_args(args):
+    """Convert args list into a dict for `prepare_configuration_dictionary`"""
+
+    path = os.path.join(os.getcwd(), os.path.dirname(sys.argv[0]))
+    path = os.path.normpath(os.path.join(path, '../lib/local'))
+
+    parser = argparse.ArgumentParser(
+            description='Configure print_info.c and git_info.f90.')
+    parser.add_argument('-d', '--dest', default=path,
+            help='Output directory. Default: %(default)s.')
+    parser.add_argument('-s', '--src', default=path,
+            help='Input directory. Default: %(default)s.')
+    parser.add_argument('config', nargs=argparse.REMAINDER,
+            help='Space-separated list of pairs of keywords and values. '
+            'See comments for permitted values.')
+    options = parser.parse_args(args)
+    if not options.config:
+        parser.print_help()
+        sys.exit(1)
+    config_it = iter(options.config)
+    config_args = dict((k,v) for (k,v) in zip(config_it, config_it))
+    return (options.src, options.dest, config_args)
+
+if __name__ == '__main__':
+
+    in_path, out_path, kwargs = parse_args(sys.argv[1:])
+    conf_dict = prepare_configuration_dictionary(**kwargs)
+    for fname in ('print_info.c', 'git_info.f90'):
+        configure_file(conf_dict, fname, in_path=in_path, out_path=out_path,
+                suffix='.in')

--- a/tools/mkconfig.py
+++ b/tools/mkconfig.py
@@ -392,9 +392,6 @@ args is the list of arguments which is re-encoded in the make.inc.
         config["defs"] = " -D".join([""]+defs)
     else:
         config["defs"] = ""
-    conf_dict = prepare_configuration_dictionary(Fortran_compiler=config['fc'], build_type=config['opt_level'], C_compiler=config['cc'])
-    configure_file(conf_dict, 'print_info.c', in_path=os.path.join(os.getcwd(), 'lib/local'), suffix='.in')
-    configure_file(conf_dict, 'git_info.f90', in_path=os.path.join(os.getcwd(), 'lib/local'), suffix='.in')
     return (MAKEFILE_TEMPLATE % config)
 
 @contextlib.contextmanager


### PR DESCRIPTION
Previously we were generating them at configuration time instead -- this
is a (undesired) change introduced when adding cmake. cmake already
produces these files correctly at build time.

Fixes #19 