### PR TITLE
First-order sanity check that qmc_state aren't being reused multiple …

### DIFF
--- a/documentation/manual/input/calcs/ccmc.rst
+++ b/documentation/manual/input/calcs/ccmc.rst
@@ -93,6 +93,11 @@ Options
         must not have a different even selection setting. To switch between using
         even selection and not a written restart file must be used.
 
+    .. warning::
+
+        This destroys the qmc_state object and so it cannot be re-used in subsequent
+        QMC calculations.
+
 .. _ccmc_table:
 
 ccmc options

--- a/documentation/manual/input/calcs/dmqmc.rst
+++ b/documentation/manual/input/calcs/dmqmc.rst
@@ -110,6 +110,11 @@ Options
         The qmc_state object must have been returned by a previous DMQMC calculation.
         The validity of this is not checked.  The system must also be unchanged.
 
+    .. warning::
+
+        This destroys the qmc_state object and so it cannot be re-used in subsequent
+        QMC calculations.
+
 .. _dmqmc_table:
 
 dmqmc options

--- a/documentation/manual/input/calcs/fciqmc.rst
+++ b/documentation/manual/input/calcs/fciqmc.rst
@@ -111,6 +111,11 @@ Options
         The qmc_state object must have been returned by a previous FCIQMC calculation.
         The validity of this is not checked.  The system must also be unchanged.
 
+    .. warning::
+
+        This destroys the qmc_state object and so it cannot be re-used in subsequent
+        QMC calculations.
+
 .. _fciqmc_table:
 
 fciqmc options

--- a/documentation/manual/input/calcs/simple_fciqmc.rst
+++ b/documentation/manual/input/calcs/simple_fciqmc.rst
@@ -78,3 +78,9 @@ Options
 
         The qmc_state object must have been returned by a previous simple FCIQMC calculation.
         The validity of this is not checked.  The system must also be unchanged.
+
+    .. warning::
+
+        This destroys the qmc_state object and so it cannot be re-used in subsequent
+        QMC calculations.
+

--- a/src/qmc.F90
+++ b/src/qmc.F90
@@ -1143,8 +1143,15 @@ contains
         use qmc_data, only: qmc_state_t
         use spawn_data, only: move_spawn_t
         use particle_t_utils, only: move_particle_t
+        use errors, only: stop_all
 
         type(qmc_state_t), intent(inout) :: qmc_state_old, qmc_state_new
+
+        ! Assume if particle_t is correctly present in qmc_state_old, other components are as well. This is a first-order
+        ! sanity check on whether qmc_state_old is actually allocated and valid (e.g. has not been already passed in to a previous
+        ! calculation and deallocated).
+        if (.not.allocated(qmc_state_old%psip_list%states)) call stop_all('move_qmc_state_t', &
+                                                                          'Attempting to restart from an invalid qmc_state.')
 
         call move_spawn_t(qmc_state_old%spawn_store%spawn, qmc_state_new%spawn_store%spawn)
         call move_spawn_t(qmc_state_old%spawn_store%spawn_recv, qmc_state_new%spawn_store%spawn_recv)


### PR DESCRIPTION
…times

Consider the input file

```
sys = ueg {
    electrons = 6,
    ms = 0,
    sym = 15,
    dim = 3,
    cutoff = 2,
    rs = 2.0,
}

qmc = {
    tau = 0.02,
    init_pop = 10,
    mc_cycles = 10,
    nreports = 10,
    target_population = 50000,
    state_size = 50000,
    spawned_state_size = 5000,
    initiator = true,
}
ref = {
    det = {1, 2, 3, 10, 11, 14},
}

qs = fciqmc {
    sys = sys,
    qmc = qmc,
    reference = ref,
}

fciqmc {
    sys = sys,
    qmc = qmc,
    reference = ref,
    qmc_state = qs,
}

fciqmc {
    sys = sys,
    qmc = qmc,
    reference = ref,
    qmc_state = qs,
}
```

The third FCIQMC calculation previously caused a segmentation fault
because we initialise its qmc_state_t object from the one passed in,
except we already moved that memory to the qmc_state_t object used in
the second calculation, so we end up accessing invalid memory. The
correct thing is to either use restart files (if you genuinely want to
restart from the first calculation twice) or to pass the qmc_state
returned by the second calculation to the third (if you want to chain
the three calculations together).