### PR TITLE
Use CMake 3.6.3 on Travis

### DIFF
--- a/.ci/install_deps.sh
+++ b/.ci/install_deps.sh
@@ -17,6 +17,23 @@ fi
 
 cd $HOME/Downloads
 
+CMAKE_VERSION="3.6.3"
+echo "-- Installing CMake"
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  if [[ -f $HOME/Deps/cmake/$CMAKE_VERSION/bin/cmake ]]; then
+    echo "-- CMake $CMAKE_VERSION FOUND in cache"
+  else
+    echo "-- CMake $CMAKE_VERSION NOT FOUND in cache"
+    target_path=$HOME/Deps/cmake/$CMAKE_VERSION
+    cmake_url="https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+    mkdir -p $target_path
+    curl -Ls $cmake_url | tar -xz -C $target_path --strip-components=1
+  fi
+elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  brew upgrade cmake
+fi
+echo "-- Done installing CMake"
+
 LUA_VERSION="5.3.4"
 echo "-- Installing Lua $LUA_VERSION"
 if [[ ! -f $LUA_ROOT/lib/liblua.a ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ language: python
 addons:
   apt:
     packages:
-      - cmake3
-      - cmake3-data
       - gfortran
       - libblas-dev
       - liblapack-dev
@@ -59,6 +57,7 @@ before_install:
 cache:
   pip: true
   directories:
+    - $HOME/Deps/cmake/3.6.3
     - $HOME/Deps/lua
     - $HOME/Deps/hdf5
     - $HOME/Deps/scalapack
@@ -79,7 +78,8 @@ before_script:
                        --mpi-with-scalapack \
                        --scalapack="-L$ScaLAPACK_ROOT/lib -lscalapack" \
                        --lanczos="-L$DEPS/trlan/lib -ltrlan" \
-                       --exe-name="hande.travis.mpi.linux.cmake.x"
+                       --exe-name="hande.travis.mpi.linux.cmake.x" \
+                       --cmake-executable="$HOME/Deps/cmake/3.6.3/bin/cmake"
       # This is equivalent to
       # cmake -H. -Bbuild \
       #           -DENABLE_HDF5=ON \
@@ -99,7 +99,8 @@ before_script:
                        --cc=gcc \
                        --lua=$LUA_ROOT \
                        --backtrace \
-                       --exe-name="hande.travis.serial.linux.cmake.x"
+                       --exe-name="hande.travis.serial.linux.cmake.x" \
+                       --cmake-executable="$HOME/Deps/cmake/3.6.3/bin/cmake"
       # This is equivalent to
       # cmake -H. -Bbuild \
       #           -DCMAKE_BUILD_TYPE=Release \

--- a/cmake/custom/lua.cmake
+++ b/cmake/custom/lua.cmake
@@ -16,3 +16,18 @@ if(LUA_ROOT)
   list(APPEND CMAKE_PREFIX_PATH ${LUA_ROOT})
 endif()
 find_package(Lua 5.3 EXACT REQUIRED)
+
+# Append the dl library to the LUA_LIBRARIES list for a statically
+# linked Lua library.
+# This contraption is needed for CMake older than 3.6.0
+# This is adapted from:
+# https://github.com/Kitware/CMake/blob/v3.8.2/Modules/FindLua.cmake
+if(CMAKE_VERSION VERSION_LESS 3.8.0)
+  if(UNIX AND NOT APPLE AND NOT BEOS)
+    # include dl library for statically-linked Lua library
+    get_filename_component(LUA_LIB_EXT ${LUA_LIBRARY} EXT)
+    if(LUA_LIB_EXT STREQUAL CMAKE_STATIC_LIBRARY_SUFFIX)
+      list(APPEND LUA_LIBRARIES ${CMAKE_DL_LIBS})
+    endif()
+  endif()
+endif()


### PR DESCRIPTION
Force usage of the minimum required CMake version (3.6) on Travis. This should ensure that the requirement is not accidentally broken because of a more modern CMake version available on the CI image.