### PR TITLE
In Weighted Sampling, Place Hamiltonian Transformation into Null Excitation Test

### DIFF
--- a/src/spawning.F90
+++ b/src/spawning.F90
@@ -184,9 +184,8 @@ contains
         call gen_excit_ptr%full(rng, sys, qmc_state%excit_gen_data, cdet, pgen, connection, hmatel, allowed)
 
         ! 2. Transform Hamiltonian matrix element by trial function.
-        call gen_excit_ptr%trial_fn(sys, cdet, connection, weights, hmatel%r)
-
         if (allowed) then
+           call gen_excit_ptr%trial_fn(sys, cdet, connection, weights, hmatel%r)
            hmatel%r = hmatel%r * calc_qn_spawned_weighting(sys, qmc_state%propagator, cdet%fock_sum, connection)
         end if
 


### PR DESCRIPTION
Addressing #29 , this fix puts Hamiltonian transformation into null excitation test, ensuring that the connection is valid before `trial_fn` attempts to create a new determinant according to `connection`.