### PR TITLE
Sanity check number of basis functions in get_reference_hdf5.

### DIFF
--- a/src/qmc.F90
+++ b/src/qmc.F90
@@ -890,7 +890,7 @@ contains
         call check_allocate('reference%occ_list0',sys%nel,ierr)
         allocate(reference%hs_occ_list0(sys%nel), stat=ierr)
         call check_allocate('reference%hs_occ_list0',sys%nel,ierr)
-        call get_reference_hdf5(ri, sys%basis%info_string_len, reference)
+        call get_reference_hdf5(ri, sys%basis%nbasis, sys%basis%info_string_len, reference)
 
         ! Need to re-calculate the reference determinant data
         call decode_det(sys%basis, reference%f0, reference%occ_list0)


### PR DESCRIPTION
This check is already performed in read_restart_hdf5 but that happens
after get_reference_hdf5 and, if the sanity check doesn't hold, a rather
confusing error message resulted.