### PR TITLE
Two-Body Reduced Density Matrix Support in DMQMC

### DIFF
--- a/documentation/manual/input/calcs/dmqmc.rst
+++ b/documentation/manual/input/calcs/dmqmc.rst
@@ -414,6 +414,29 @@ operators options
 
     Only currently implemented for the UEG.
 
+``rdm2_frequency``
+    type: integer.
+
+    Optional.  Default: 0.
+
+    If non-zero, calculate and print two-body reduced density matrix (two-body Green function)
+    at the end of each :math:`N` cycles. Here :math:`N` is the number specified and 
+    definition of the two-body reduced density matrix is given by:
+
+    .. math::
+
+        d_{abij} = \langle c_a^\dagger c_b^\dagger c_i c_j \rangle = 
+            \sum_{ij} \rho_{ij} \langle \phi_i | c_a^\dagger c_b^\dagger c_i c_j | \phi_j \rangle
+
+``rdm2_filename``
+    type: string.
+
+    Optional.  Default: 'RDM'.
+
+    Specifies the prefix of filenames to which the two-body density matries are written. 
+    RDM-2 files will be named 'PREFIX.X' where 'PREFIX' is the prefix specified here
+    and X is an increasing number.
+
 ``structure_factor``
     type: float
 

--- a/src/check_input.f90
+++ b/src/check_input.f90
@@ -290,6 +290,8 @@ contains
             call stop_all(this, 'The replica_tricks option must be used in order to calculate the Renyi-2 entropy.')
         if (doing_dmqmc_calc(dmqmc_HI_energy) .and. (.not. dmqmc_in%symmetric)) &
             call stop_all(this, 'Evaluation of interaction picture Hamiltonian only possible when using symmetric algorithm.')
+        if (dmqmc_in%green_calc_frequency /= 0 .and. sys%system /= read_in) &
+            call stop_all(this, "2-body density matrices not implemented for this system type.")
 
         if (dmqmc_in%all_spin_sectors) then
             if (abs(sys%heisenberg%magnetic_field) > depsilon .or. &
@@ -369,7 +371,7 @@ contains
         end if
 
         if (ccmc_in%density_matrices .and. sys%system /= read_in) then
-            call stop_all(this, "CCMC density matrices not implemented for this system type.")
+            call stop_all(this, "2-body density matrices not implemented for this system type.")
         end if
 
         if (sys%read_in%comp .and. ccmc_in%linked) call stop_all(this, 'Linked complex CCMC not yet implemented')

--- a/src/dmqmc.f90
+++ b/src/dmqmc.f90
@@ -360,6 +360,12 @@ contains
                 ! Update the time for the start of the next iteration.
                 t1 = t2
 
+                ! Call RDM-2 (Green Function) routines if conditions are met.
+                if (dmqmc_in%green_calc_frequency /= 0 .and. mod(ireport*qmc_in%ncycles, dmqmc_in%green_calc_frequency) == 0) then
+                    call calculate_green_function(sys, qs%psip_list, weighted_sampling, dmqmc_estimates%green)
+                    call write_green_function(sys, qs%ref, dmqmc_in%green_file_prefix, dmqmc_estimates%green)
+                end if
+
                 if (soft_exit) exit outer_loop
 
             end do

--- a/src/dmqmc_data.f90
+++ b/src/dmqmc_data.f90
@@ -215,6 +215,12 @@ type dmqmc_in_t
     logical :: calc_struc_fac = .false.
     ! Maximum momentum transfer to consider in structure factor (in terms of the Fermi wave vector).
     real(p) :: struc_fac_qmax = 0.0
+    ! If non-zero RDM-2 will be evalutated at the end of each N cycles.
+    ! NB: Here RDM-2 means the 2-body Green function (not to be confused with the one for subsystems):
+    !     < c_a^\dag c_b^\dag c_i c_j >
+    integer :: green_calc_frequency = 0
+    ! Filename prefix to write RDM-2 (Green Function) to.
+    character(10) :: green_file_prefix = 'RDM'
 
 end type dmqmc_in_t
 
@@ -285,6 +291,9 @@ type dmqmc_estimates_t
     ! This array is used to hold the number of particles on each excitation
     ! level of the density matrix.
     real(p), allocatable :: excit_dist(:) ! (0:max_number_excitations)
+
+    ! Estimation for RDM-2 (2-body Green Functions)
+    real(p), allocatable :: green(:, :)
 
     ! Momentum distribution.
     type(momentum_corr_t) :: mom_dist

--- a/src/dmqmc_procedures.F90
+++ b/src/dmqmc_procedures.F90
@@ -170,6 +170,13 @@ contains
         if (dmqmc_in%calc_struc_fac) call allocate_kspace_correlation_functions(sys, dmqmc_in%struc_fac_qmax, .false., &
                                                                                dmqmc_estimates%struc_fac%f_k, &
                                                                                dmqmc_estimates%struc_fac%kpoints)
+        ! The 2-Body RDM (Green Function).
+        if (dmqmc_in%green_calc_frequency /= 0) then
+            associate(nbasis=>sys%basis%nbasis)
+                allocate(dmqmc_estimates%green(nbasis*(nbasis-1)/2,nbasis*(nbasis-1)/2), stat=ierr)
+                call check_allocate('dmqmc_estimates%green', nbasis**2*(nbasis-1)**2/4, ierr)
+            end associate
+        end if
 
     end subroutine init_dmqmc
 

--- a/src/lua_hande_calc.f90
+++ b/src/lua_hande_calc.f90
@@ -1405,7 +1405,7 @@ contains
         character(30), parameter :: op_keys(14)    = [character(30) :: 'renyi2', 'energy', 'energy2', 'staggered_magnetisation',  &
                                                                        'correlation', 'excit_dist', 'kinetic_energy',             &
                                                                        'H0_energy', 'potential_energy', 'HI_energy', 'mom_dist',  &
-                                                                       'structure_factor', 'rdm2_freqency', 'rdm2_filename']
+                                                                       'structure_factor', 'rdm2_frequency', 'rdm2_filename']
         character(30), parameter :: rdm_keys(9)   = [character(30) :: 'spawned_state_size', 'rdms', 'ground_state',              &
                                                                       'ground_state_start', 'instantaneous', 'write',              &
                                                                       'concurrence', 'von_neumann', 'renyi2']

--- a/src/lua_hande_calc.f90
+++ b/src/lua_hande_calc.f90
@@ -1402,10 +1402,10 @@ contains
         character(30), parameter :: ip_keys(6)    = [character(30) :: 'target_beta', 'initial_beta', 'initial_matrix',           &
                                                                       'grand_canonical_initialisation', 'metropolis_attempts',   &
                                                                       'symmetric']
-        character(30), parameter :: op_keys(12)    = [character(30) :: 'renyi2', 'energy', 'energy2', 'staggered_magnetisation',  &
+        character(30), parameter :: op_keys(14)    = [character(30) :: 'renyi2', 'energy', 'energy2', 'staggered_magnetisation',  &
                                                                        'correlation', 'excit_dist', 'kinetic_energy',             &
                                                                        'H0_energy', 'potential_energy', 'HI_energy', 'mom_dist',  &
-                                                                       'structure_factor']
+                                                                       'structure_factor', 'rdm2_freqency', 'rdm2_filename']
         character(30), parameter :: rdm_keys(9)   = [character(30) :: 'spawned_state_size', 'rdms', 'ground_state',              &
                                                                       'ground_state_start', 'instantaneous', 'write',              &
                                                                       'concurrence', 'von_neumann', 'renyi2']
@@ -1498,6 +1498,8 @@ contains
                 call aot_get_val(dmqmc_in%struc_fac_qmax, err, lua_state, table, 'structure_factor')
                 dmqmc_in%calc_struc_fac = .true.
             end if
+            call aot_get_val(dmqmc_in%green_calc_frequency, err, lua_state, table, 'rdm2_frequency', default=0)
+            call aot_get_val(dmqmc_in%green_file_prefix, err, lua_state, table, 'rdm2_filename', default='RDM')
             call aot_get_val(dmqmc_in%calc_excit_dist, err, lua_state, table, 'excit_dist')
             call warn_unused_args(lua_state, op_keys, table)
             call aot_table_close(lua_state, table)


### PR DESCRIPTION
This pull request adds support of 2-body reduced density matrix (RDM2) to DMQMC:

```
< c_a^\dag c_b^\dag c_i c_j >
```

To avoid confusion with the original RDM procedures for the truncated Hilbert space, `green_function` instead of `rdm` is used as variable name and the `rdm2` interface is put under the operators table.