### PR TITLE
CMake: HDF5 detection and update docs

### DIFF
--- a/.default.nix
+++ b/.default.nix
@@ -33,7 +33,6 @@ in
       libuuid
       lua5_3
       openmpi
-      pipenv
       python3Full
       python3Packages.matplotlib
       python3Packages.numpy

--- a/cmake/autocmake/configure.py
+++ b/cmake/autocmake/configure.py
@@ -57,7 +57,6 @@ def run_cmake(command, build_path, default_build_path):
     Execute CMake command.
     """
     from subprocess import Popen, PIPE
-    from shutil import rmtree
 
     topdir = os.getcwd()
     p = Popen(command, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE)
@@ -91,11 +90,6 @@ def run_cmake(command, build_path, default_build_path):
     if configuration_successful:
         save_setup_command(sys.argv, build_path)
         print_build_help(build_path, default_build_path)
-    else:
-        if (build_path == default_build_path):
-            # remove build_path iff not set by the user
-            # otherwise removal can be dangerous
-            rmtree(default_build_path)
 
 
 def print_build_help(build_path, default_build_path):

--- a/cmake/custom/hdf5.cmake
+++ b/cmake/custom/hdf5.cmake
@@ -10,16 +10,26 @@
 # Variables defined::
 #
 #   USE_HDF5
+#   HDF5_ROOT
 #   HDF5_Fortran_LIBRARIES
 #   HDF5_INCLUDE_DIRS
 #
 # autocmake.yml configuration::
 #
-#   docopt: "--hdf5=<HDF5> Enable HDF5 [default: True]."
-#   define: "'-DENABLE_HDF5=\"{0}\"'.format(arguments['--hdf5'])"
+#   docopt:
+#     - "--hdf5=<HDF5_ROOT> Specify the path to the HDF5 installation to use [default: '']."
+#     - "--without-hdf5=<HDF5_ROOT> Specify the path to the HDF5 installation to use [default: '']."
+#   define:
+#     - "'-DENABLE_HDF5=\"{0}\"'.format('FALSE' if arguments['--hdf5'] in ['False', 'false', 'OFF', 'off'] else 'TRUE')"
+#     - "'-DHDF5_ROOT=\"{0}\"'.format(arguments['--hdf5'])"
 
 option_with_print(ENABLE_HDF5 "Enable usage of HDF5 (requires Fortran 2003 bindings)" ON)
 set(USE_HDF5 OFF)
+# Just unset the variable if empty
+# This avoids an annoying CMake warning _and_ mucking up the environment variable.
+if(NOT HDF5_ROOT)
+  unset(HDF5_ROOT)
+endif()
 if(ENABLE_HDF5)
   find_package(HDF5 1.8.15 COMPONENTS Fortran REQUIRED)
   # Was the Fortran 2003 interface to HDF5 enabled?

--- a/cmake/custom/hdf5.cmake
+++ b/cmake/custom/hdf5.cmake
@@ -18,7 +18,6 @@
 #
 #   docopt:
 #     - "--hdf5=<HDF5_ROOT> Specify the path to the HDF5 installation to use [default: '']."
-#     - "--without-hdf5=<HDF5_ROOT> Specify the path to the HDF5 installation to use [default: '']."
 #   define:
 #     - "'-DENABLE_HDF5=\"{0}\"'.format('FALSE' if arguments['--hdf5'] in ['False', 'false', 'OFF', 'off'] else 'TRUE')"
 #     - "'-DHDF5_ROOT=\"{0}\"'.format(arguments['--hdf5'])"

--- a/cmake/custom/hdf5.cmake
+++ b/cmake/custom/hdf5.cmake
@@ -38,8 +38,9 @@ if(ENABLE_HDF5)
       HDF5_HAS_Fortran2003-test-output
     )
   if(NOT HDF5_HAS_Fortran2003)
-         message(FATAL_ERROR "HDF5 requested, but library was not compiled with --enable-fortran2003 Compiling a simple test executable failed with the following message:
-${HDF5_HAS_Fortran2003-test-output}")
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/HDF5_HAS_Fortran2003-test.log ${HDF5_HAS_Fortran2003-test-output})
+    message(FATAL_ERROR "HDF5 requested, but library was not compiled with --enable-fortran2003 \
+Compiling a simple test executable failed, consult the log file: ${CMAKE_CURRENT_BINARY_DIR}/HDF5_HAS_Fortran2003-test.log")
   else()
     set(USE_HDF5 ON)
   endif()

--- a/cmake/custom/hdf5.cmake
+++ b/cmake/custom/hdf5.cmake
@@ -22,11 +22,6 @@ option_with_print(ENABLE_HDF5 "Enable usage of HDF5 (requires Fortran 2003 bindi
 set(USE_HDF5 OFF)
 if(ENABLE_HDF5)
   find_package(HDF5 1.8.15 COMPONENTS Fortran REQUIRED)
-  if(HDF5_IS_PARALLEL)
-    message(STATUS "Parallel HDF5 FOUND")
-  else()
-    message(STATUS "Parallel HDF5 NOT FOUND")
-  endif()
   # Was the Fortran 2003 interface to HDF5 enabled?
   # Compile an example from the HDF5 website:
   # https://support.hdfgroup.org/HDF5/examples/f-src.html
@@ -39,9 +34,12 @@ if(ENABLE_HDF5)
       -DINCLUDE_DIRECTORIES=${HDF5_INCLUDE_DIRS}
     LINK_LIBRARIES
       ${HDF5_Fortran_LIBRARIES}
+    OUTPUT_VARIABLE
+      HDF5_HAS_Fortran2003-test-output
     )
   if(NOT HDF5_HAS_Fortran2003)
-    message(FATAL_ERROR "HDF5 requested, but library was not compiled with --enable-fortran2003")
+         message(FATAL_ERROR "HDF5 requested, but library was not compiled with --enable-fortran2003 Compiling a simple test executable failed with the following message:
+${HDF5_HAS_Fortran2003-test-output}")
   else()
     set(USE_HDF5 ON)
   endif()

--- a/cmake/downloaded/autocmake_cc.cmake
+++ b/cmake/downloaded/autocmake_cc.cmake
@@ -1,5 +1,5 @@
-# (c) https://github.com/coderefinery/autocmake/blob/master/AUTHORS.md
-# licensed under BSD-3: https://github.com/coderefinery/autocmake/blob/master/LICENSE
+# (c) https://github.com/dev-cafe/autocmake/blob/master/AUTHORS.md
+# licensed under BSD-3: https://github.com/dev-cafe/autocmake/blob/master/LICENSE
 
 #.rst:
 #

--- a/cmake/downloaded/autocmake_default_build_paths.cmake
+++ b/cmake/downloaded/autocmake_default_build_paths.cmake
@@ -1,5 +1,5 @@
-# (c) https://github.com/coderefinery/autocmake/blob/master/AUTHORS.md
-# licensed under BSD-3: https://github.com/coderefinery/autocmake/blob/master/LICENSE
+# (c) https://github.com/dev-cafe/autocmake/blob/master/AUTHORS.md
+# licensed under BSD-3: https://github.com/dev-cafe/autocmake/blob/master/LICENSE
 
 #.rst:
 #

--- a/cmake/downloaded/autocmake_definitions.cmake
+++ b/cmake/downloaded/autocmake_definitions.cmake
@@ -1,5 +1,5 @@
-# (c) https://github.com/coderefinery/autocmake/blob/master/AUTHORS.md
-# licensed under BSD-3: https://github.com/coderefinery/autocmake/blob/master/LICENSE
+# (c) https://github.com/dev-cafe/autocmake/blob/master/AUTHORS.md
+# licensed under BSD-3: https://github.com/dev-cafe/autocmake/blob/master/LICENSE
 
 #.rst:
 #

--- a/cmake/downloaded/autocmake_fc.cmake
+++ b/cmake/downloaded/autocmake_fc.cmake
@@ -1,5 +1,5 @@
-# (c) https://github.com/coderefinery/autocmake/blob/master/AUTHORS.md
-# licensed under BSD-3: https://github.com/coderefinery/autocmake/blob/master/LICENSE
+# (c) https://github.com/dev-cafe/autocmake/blob/master/AUTHORS.md
+# licensed under BSD-3: https://github.com/dev-cafe/autocmake/blob/master/LICENSE
 
 #.rst:
 #

--- a/cmake/downloaded/autocmake_python_interpreter.cmake
+++ b/cmake/downloaded/autocmake_python_interpreter.cmake
@@ -1,5 +1,5 @@
-# (c) https://github.com/coderefinery/autocmake/blob/master/AUTHORS.md
-# licensed under BSD-3: https://github.com/coderefinery/autocmake/blob/master/LICENSE
+# (c) https://github.com/dev-cafe/autocmake/blob/master/AUTHORS.md
+# licensed under BSD-3: https://github.com/dev-cafe/autocmake/blob/master/LICENSE
 
 #.rst:
 #

--- a/cmake/downloaded/autocmake_safeguards.cmake
+++ b/cmake/downloaded/autocmake_safeguards.cmake
@@ -1,5 +1,5 @@
-# (c) https://github.com/coderefinery/autocmake/blob/master/AUTHORS.md
-# licensed under BSD-3: https://github.com/coderefinery/autocmake/blob/master/LICENSE
+# (c) https://github.com/dev-cafe/autocmake/blob/master/AUTHORS.md
+# licensed under BSD-3: https://github.com/dev-cafe/autocmake/blob/master/LICENSE
 
 #.rst:
 #

--- a/cmake/downloaded/autocmake_src.cmake
+++ b/cmake/downloaded/autocmake_src.cmake
@@ -1,5 +1,5 @@
-# (c) https://github.com/coderefinery/autocmake/blob/master/AUTHORS.md
-# licensed under BSD-3: https://github.com/coderefinery/autocmake/blob/master/LICENSE
+# (c) https://github.com/dev-cafe/autocmake/blob/master/AUTHORS.md
+# licensed under BSD-3: https://github.com/dev-cafe/autocmake/blob/master/LICENSE
 
 #.rst:
 #

--- a/cmake/update.py
+++ b/cmake/update.py
@@ -9,7 +9,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     sys.exit(-1)
 
 
-AUTOCMAKE_GITHUB_URL = 'https://github.com/coderefinery/autocmake/raw/master/'
+AUTOCMAKE_GITHUB_URL = 'https://github.com/dev-cafe/autocmake/raw/master/'
 
 
 def licensing_info():

--- a/cmakeconfig.py
+++ b/cmakeconfig.py
@@ -39,7 +39,6 @@ Options:
   --pop-size=<HANDE_POP_SIZE>            An integer among 32 or 64 [default: 32].
   --exe-name=<HANDE_EXE_NAME>            [default: "hande.cmake.x"].
   --hdf5=<HDF5_ROOT>                     Specify the path to the HDF5 installation to use [default: ''].
-  --without-hdf5=<HDF5_ROOT>             Specify the path to the HDF5 installation to use [default: ''].
   --uuid=<UUID>                          Whether to activate UUID generation [default: True].
   --lanczos=<TRLan_LIBRARIES>            Set TRLan libraries to be linked in [default: ''].
   --single                               Enable usage of single precision, where appropriate [default: False].

--- a/cmakeconfig.py
+++ b/cmakeconfig.py
@@ -38,7 +38,8 @@ Options:
   --det-size=<HANDE_DET_SIZE>            An integer among 32 or 64 [default: 32].
   --pop-size=<HANDE_POP_SIZE>            An integer among 32 or 64 [default: 32].
   --exe-name=<HANDE_EXE_NAME>            [default: "hande.cmake.x"].
-  --hdf5=<HDF5>                          Enable HDF5 [default: True].
+  --hdf5=<HDF5_ROOT>                     Specify the path to the HDF5 installation to use [default: ''].
+  --without-hdf5=<HDF5_ROOT>             Specify the path to the HDF5 installation to use [default: ''].
   --uuid=<UUID>                          Whether to activate UUID generation [default: True].
   --lanczos=<TRLan_LIBRARIES>            Set TRLan libraries to be linked in [default: ''].
   --single                               Enable usage of single precision, where appropriate [default: False].
@@ -82,7 +83,8 @@ def gen_cmake_command(options, arguments):
     command.append('-DHANDE_DET_SIZE="{0}"'.format(arguments['--det-size']))
     command.append('-DHANDE_POP_SIZE="{0}"'.format(arguments['--pop-size']))
     command.append('-DHANDE_EXE_NAME="{0}"'.format(arguments['--exe-name']))
-    command.append('-DENABLE_HDF5="{0}"'.format(arguments['--hdf5']))
+    command.append('-DENABLE_HDF5="{0}"'.format('FALSE' if arguments['--hdf5'] in ['False', 'false', 'OFF', 'off'] else 'TRUE'))
+    command.append('-DHDF5_ROOT="{0}"'.format(arguments['--hdf5']))
     command.append('-DENABLE_UUID="{0}"'.format(arguments['--uuid']))
     command.append('-DTRLan_LIBRARIES="{0}"'.format(arguments['--lanczos']))
     command.append('-DENABLE_SINGLE_PRECISION="{0}"'.format(arguments['--single']))


### PR DESCRIPTION
- Update building with CMake docs.
- Modify the way the `--hdf5` flag works. It now accepts a path to a custom compiled version of HDF5 and internally sets `HDF5_ROOT`. This is then similar to the way `--lua` works, which is less confusing for the user. **Note** setting `LUA_ROOT` and `HDF5_ROOT` as environment variables achieves the same effect as using the configuration script flags (according to CMake docs and my tests, at least)
- The compatibility check between HDF5 and Fortran compiler now logs its output to a file upon failure. This should help the user debug the problem or at least provide more complete information to the developers.