### PR TITLE
Updated (old) Makefile to avoid duplication of objects (git_info.o).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ $(BIN_DIR)/$(PROG): $(BIN_DIR)/$(PROG_VERSION) $(call md5_check, $(BIN_DIR)/$(PR
 	$(LINK_MACRO)
 
 $(BIN_DIR)/$(PROG_VERSION): $(OBJECTS) | $(BIN_DIR)
-	$(LD) -o $@ $(LDFLAGS) -I $(DEST) $(OBJECTS) $(LIBS)
+	$(LD) -o $@ $(LDFLAGS) -I $(DEST) $^ $(LIBS)
 
 # shortcut
 program: $(BIN_DIR)/$(PROG)


### PR DESCRIPTION
Occasionally object files which are forced to be rebuilt will appear twice in the Makefile linker prerequisites.  This uses the $^ make variable to avoid that.