### PR TITLE
Fix invalid Fortran format string in json_out.f90

### DIFF
--- a/lib/local/json_out.f90
+++ b/lib/local/json_out.f90
@@ -110,7 +110,7 @@ contains
         character(3) :: xc
 
         xc = indent_level(js%level)
-        write (js%io,'('//xc//'a)', advance='no') '"'//trim(key)//'": '
+        write (js%io,'('//xc//',a)', advance='no') '"'//trim(key)//'": '
 
     end subroutine write_key
 


### PR DESCRIPTION
The format string `'('//xc//'a)'` in write_key produces e.g. `'(5Xa)'`, which places two format descriptors (`5X` and `a`) without a comma separator. This is invalid Fortran and causes a compilation failure with GFortran.